### PR TITLE
Bugfix - file extension applied twice to output files.

### DIFF
--- a/src/main/java/io/aleksander/cbac/converter/Converter.java
+++ b/src/main/java/io/aleksander/cbac/converter/Converter.java
@@ -41,10 +41,7 @@ public class Converter {
     ArchiveCreator archiveCreator =
         ArchiveCreatorSimpleFactory.forOutputFileFormat(settings.getOutputFileFormat());
 
-    String comicArchiveFileName =
-        (new FileUtil())
-            .createOutputFileNameWithExtension(
-                conversion.getFile(), settings.getOutputFileFormat());
+    String comicArchiveFileName = (new FileUtil()).fileNameWithoutExtension(conversion.getFile());
     comicArchiveFileName =
         outputDirectory.getAbsolutePath() + File.separator + comicArchiveFileName;
 

--- a/src/main/java/io/aleksander/cbac/utils/FileUtil.java
+++ b/src/main/java/io/aleksander/cbac/utils/FileUtil.java
@@ -22,7 +22,7 @@ public class FileUtil {
    * @param numberOfPages the total number of pages in the comic book.
    * @return a file name padded with sufficient 0s so that the file system will sort them correctly.
    */
-  public String createPaddedFileNameForPage(int page, int numberOfPages) {
+  public String createPaddedFileNameForPage(final int page, final int numberOfPages) {
     StringBuilder string = new StringBuilder(String.valueOf(page));
     int places = String.valueOf(numberOfPages).length();
 
@@ -62,10 +62,10 @@ public class FileUtil {
    * @throws IOException if saving the file failed.
    */
   public void writeBufferedImageToDisk(
-      BufferedImage bufferedImage,
-      File destinationFolder,
-      String fileName,
-      OutputImageFormat outputImageFormat)
+      final BufferedImage bufferedImage,
+      final File destinationFolder,
+      final String fileName,
+      final OutputImageFormat outputImageFormat)
       throws IOException {
     File outputImage =
         new File(

--- a/src/main/java/io/aleksander/cbac/utils/FileUtil.java
+++ b/src/main/java/io/aleksander/cbac/utils/FileUtil.java
@@ -1,6 +1,5 @@
 package io.aleksander.cbac.utils;
 
-import io.aleksander.cbac.model.OutputFileFormat;
 import io.aleksander.cbac.model.OutputImageFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,6 +8,7 @@ import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 
 public class FileUtil {
   private static final Logger logger = LoggerFactory.getLogger(FileUtil.class);
@@ -34,18 +34,22 @@ public class FileUtil {
   }
 
   /**
-   * Takes the name of an input file and returns a copy where the extension has been changed for the
-   * one specified.
+   * Returns the file name of a File without its extension.
    *
-   * @param inputFile
-   * @param outputFileFormat
-   * @return a file name using the specified extension.
+   * @param inputFile the inputFile to query.
+   * @return the file name without the extension.
    */
-  public String createOutputFileNameWithExtension(
-      File inputFile, OutputFileFormat outputFileFormat) {
-    String fileNameWithoutExtension =
-        inputFile.getName().substring(0, inputFile.getName().lastIndexOf('.'));
-    return fileNameWithoutExtension + "." + outputFileFormat.getExtension();
+  public String fileNameWithoutExtension(final File inputFile) {
+    Objects.requireNonNull(inputFile, "Can't determine file name for null");
+
+    int notFound = -1;
+    int indexOfExtension = inputFile.getName().lastIndexOf('.');
+
+    if (indexOfExtension == notFound) {
+      return inputFile.getName();
+    }
+
+    return inputFile.getName().substring(0, indexOfExtension);
   }
 
   /**

--- a/src/test/java/io/aleksander/cbac/utils/FileUtilTest.java
+++ b/src/test/java/io/aleksander/cbac/utils/FileUtilTest.java
@@ -1,7 +1,5 @@
 package io.aleksander.cbac.utils;
 
-import io.aleksander.cbac.model.OutputFileFormat;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -25,16 +23,17 @@ class FileUtilTest {
   @CsvSource({"0,10,00", "9, 10, 09", "98, 100, 098"})
   void createPaddedFileName_pageNeedsPadding_returnsPageNumberWithPadding(
       int pageNumber, int totalPages, String expectedFileName) {
-      String paddedFileName = fileUtil.createPaddedFileNameForPage(pageNumber, totalPages);
-      assertEquals(expectedFileName, paddedFileName);
+    String paddedFileName = fileUtil.createPaddedFileNameForPage(pageNumber, totalPages);
+    assertEquals(expectedFileName, paddedFileName);
   }
 
-  @Test
-  void createOutputFileNameWithExtension_inputFileIsPdfAndOutputFormatIsCbz_returnsCbzFileName() {
-    File inputFile = new File("a_input.pdf");
-    String expected = "a_input.cbz";
+  @ParameterizedTest
+  @CsvSource({"a.pdf, a", "b, b"})
+  void fileNameWithoutExtension_returnsFileNameWithoutExtensionIfPresent(
+      String input, String expected) {
+    File inputFile = new File(input);
 
-    String result = fileUtil.createOutputFileNameWithExtension(inputFile, OutputFileFormat.CBZ);
+    String result = fileUtil.fileNameWithoutExtension(inputFile);
     assertEquals(expected, result);
   }
 }


### PR DESCRIPTION
File extension was being applied twice to output files resulting in file names such as "Absalom vol1.cbz.cbz".